### PR TITLE
Fix get_meas_interval()

### DIFF
--- a/src/EdistribucionAPI/Edistribucion.py
+++ b/src/EdistribucionAPI/Edistribucion.py
@@ -474,7 +474,7 @@ class Edistribucion():
             1362,
             "WP_Measure_v3_CTRL/ACTION$getChartPointsByRange",
             "WP_Measure_Detail_Filter_Advanced_v3",
-            {"contId": cont, "startDate": startDate, "endDate": endDate}
+            {"contId": cont, "type": 4, "startDate": startDate, "endDate": endDate}
         )
 
         r = self.__run_action_command(action)


### PR DESCRIPTION
The method was returning an array with only 1 element, the data for the `startDate`, instead of one element for each day of the entire requested interval. Inspecting the traffic, adding the `"type": 4` property seems to make it clear for the backend that we want to perform an interval operation and fixes the problem.